### PR TITLE
japanize_matplotlibのインストールコマンド追加

### DIFF
--- a/week02/0202_matplotlib.ipynb
+++ b/week02/0202_matplotlib.ipynb
@@ -19,6 +19,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# 必要なライブラリのインストール\n",
+    "!pip install -qq japanize_matplotlib\n",
+    "\n",
     "# 利用するライブラリを読み込む\n",
     "# as で別名をつけることができる（長いライブラリ名の省略）\n",
     "import japanize_matplotlib  # matplotlibの日本語化\n",
@@ -29,6 +32,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "fe0caebd",
    "metadata": {},
@@ -97,6 +101,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "f5024c73",
    "metadata": {},
@@ -188,6 +193,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "cf273984",
    "metadata": {},
@@ -206,6 +212,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "5c7230aa",
    "metadata": {},
@@ -257,6 +264,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "0f1ef630",
    "metadata": {},
@@ -309,6 +317,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "85bc31c5",
    "metadata": {},
@@ -361,6 +370,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "ce3411e8",
    "metadata": {},
@@ -412,6 +422,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "6f311e8b",
    "metadata": {},
@@ -460,6 +471,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "808a60fd",
    "metadata": {},


### PR DESCRIPTION
Google Colabで実行するとき、`japanize_matplotlib`ライブラリがなくエラーが出るため、インストールコマンドを追加しました。